### PR TITLE
io/sac: support deast & dnorth via user7 & user8

### DIFF
--- a/pisces/commands/sac2db.py
+++ b/pisces/commands/sac2db.py
@@ -195,6 +195,8 @@ def main(**kwargs):
     prefix : str
         Target core tables using 'account.prefix' naming.
     absolute_paths : bool
+    bbfk : bool
+        Pull in deast & dnorth info from user7 & user8 header fields
     file_list : str
         Name of a text file containing full SAC file names.
     files : list

--- a/pisces/io/sac.py
+++ b/pisces/io/sac.py
@@ -348,6 +348,45 @@ def sachdr2site(header):
     return [sitedict] or []
 
 
+def sachdr2arraysite(header):
+    """
+        Provide a SAC header dictionary, get a site table dictionary.
+        This is a slight modification of sachdr2site that handles deast
+        & dnorth being in SAC's user7 & user8 header fields (a poor
+        but documented standard that is the de facto appoach
+        - see SAC's BBFK or ARRAYMAP or BRTT's db2sac in Antelope).
+        
+        Note that user7 & user8 are expected to be in km (consistent
+        with SAC expectations).
+        
+        """
+    sac_site = [('kstnm', 'sta'),
+                ('stla', 'lat'),
+                ('stlo', 'lon'),
+                ('stel', 'elev'),
+                ('user7','deast'),
+                ('user8','dnorth')]
+        
+                sitedict = {}
+                for hdr, col in sac_site:
+                    val = header.get(hdr, None)
+                        sitedict[col] = val if val != SACDEFAULT[hdr] else None
+
+# clean up
+try:
+    sitedict['elev'] /= 1000.0
+    except (TypeError, KeyError):
+        #no 'elev'
+        pass
+
+sitedict = _cast_float(sitedict, ['lat', 'lon', 'elev', 'deast', 'dnorth'])
+    sitedict = _clean_str(sitedict, ['sta'])
+    
+    sitedict['sta'] = sitedict['sta'].strip()[:6]
+    
+    return [sitedict] or []
+
+
 def sachdr2sitechan(header):
     """
     Provide a sac header dictionary, get a sitechan table dictionary.
@@ -783,8 +822,11 @@ def site2sachdr(s):
     """
     Accepts a fielded site table row and returns a dictionary of corresponding
     sac header field/value pairs.
+    
+    June 13, 2016 - added deast/dnorth output to SAC user7/8 header fields
     """
-    keymap = {'stel': 'elev', 'stal': 'lat', 'stlo': 'lon'}
+    keymap = {'stel': 'elev', 'stal': 'lat', 'stlo': 'lon',
+        'user7': 'deast', 'user8': 'dnorth'}
     hdr = _buildhdr(keymap, s)
     return hdr
 


### PR DESCRIPTION
Array position information is often stored in the user7, user8, & user9 SAC header fields as kilometers east, north and vertically up.  This is not the greatest use of the SAC header but it is well adopted and documented by SAC and several other software programs that deal with array data.  To support the output of array info from a database using pisces, I edited the site2sachdr method to output site.deast & site.dnorth to the user7 & user8 SAC header fields (there is no site.dvert to populate user9).  For inputting array info, I created a copy of the sachdr2site method called sachdr2arraysite.  I then added a new switch for sac2db called "bbfk" (this is named after the main function in SAC that uses this feature - I'm starting to think that "array" would be a better flag here) that would potentially choose whether or not to import info from user7 & user8 (true being import, false would not (default)).  So far this implementation is not working because I am not sure of the best approach to implement the option.  Some possibilities:
* Replace sachdr2site with sachdr2arraysite and have no array switch.  Basically this always takes user7 & user8 fields and injects them into the database.  This seems like the smallest code impact (meaning less maintenance) but will introduce garbage into the database if a user is unaware that user7/8 are used for array info and has other info in those fields.  They would have to clean their files beforehand or fix the database afterwards in this case.  So I vote no on this.
* Replace sachdr2site with sachdr2arraysite and have the array switch (default false) passed down to the new sachdr2site.  This makes the sac definition flexible and keeps the impact higher up minimal (sac2db & sachdr2tables just passes the switches down to the methods as needed).  This feels like the best approach to me.
* Replace sachdr2site with sachdr2arraysite and have the array switch implemented in sac2db.  This requires us to cleanup the sac files or the db.  This means extra cycles and puts the burden on the high level code.  So I vote no on this too.
* sachdr2whatever duplication each time we find an optional convention such as this.  I vote no on this to minimize duplication.

Thoughts?