### PR TITLE
Fix tagid and Wftag in KB Core and CSS3 schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## dev
+
+* `wftag` now parsed as a float instead of an integer in KB Core and CSS3 schemas
+* `Wftag` primary keys are `tagname`, `tagid`, and `wfid` instead of just `tagid`
+
 ## 0.3.0
 
 * Python 3 support!

--- a/pisces/commands/mseed2db.py
+++ b/pisces/commands/mseed2db.py
@@ -1,0 +1,103 @@
+"""
+Module for creating wfdisc rows from miniSEED files.
+
+"""
+import os
+
+from obspy import read
+import sqlalchemy.exc as exc
+
+from pisces.util import get_lastids, url_connect
+from .util import get_or_create_tables, dicts2rows, get_files
+import pisces.io.mseed as mseed
+
+def make_atomic(last, **rows):
+    """
+    Unify related table instances/row, including: ids, dir, and dfile
+
+    Parameters
+    ----------
+    last : obspy.AttributeDict
+        {'keyvalue': lastid instance, ...}
+    rows : dict
+        {'canonical tablename': [list of row instances], ...}
+        These row instances are related.
+
+    """ 
+    for wfdisc in rows.get('wfdisc', []):
+        wfdisc.wfid = next(last.wfid)
+    
+    for sitechan in rows.get('sitechan', []):
+        # XXX: this is wrong, as each new sitechan doesn't automatically get a
+        # new chanid, but we accept this for now, since duplicate sitechans
+        # will be rejected upon database write.
+        sitechan.chanid = next(last.chanid)
+
+
+def main(session, files=None, file_list=None, prefix=None, absolute_paths=False):
+    """
+    session : SQLAlchemy.orm.Session instance
+    tables : list
+        Canonical names for desired database tables.
+    prefix : str
+        Target core tables using 'account.prefix' naming.
+    absolute_paths : bool
+
+    """
+    if file_list:
+        files = get_files(file_list)
+    else:
+        files = files
+
+    tables = get_or_create_tables(session, prefix=prefix, create=True)
+
+    lastids = ['chanid', 'wfid']
+    last = get_lastids(session, tables['lastid'], lastids, create=True)
+
+    for msfile in files:
+        print(msfile)
+
+        # row_dicts = get_row_dicts(item)
+
+        st = read(msfile, format='MSEED', details=True, headonly=True)
+        # a single miniSEED file may be multiple traces.  we need to identify the
+        # file offsets (bytes) to each trace.  Traces are added to the Stream in
+        # order, with enough header information to calculate that.
+        foff = 0
+        for tr in st:
+            rows = mseed.mseedhdr2tables(tr.stats, wfdisc=tables['wfdisc'],
+                                         site=tables['site'], sitechan=tables['sitechan'],
+                                         affiliation=tables['affiliation'])
+
+            foff += tr.stats.mseed.number_of_records * tr.stats.mseed.record_length
+            rows['wfdisc'][0].foff = foff
+            rows['wfdisc'][0].dfile = os.path.basename(msfile)
+            
+            if absolute_paths:
+                idir = os.path.dirname(os.path.realpath(msfile))
+            else:
+                idir = os.path.dirname(msfile)
+                # make sure relative paths are non-empty
+                if idir == '':
+                   idir = '.'
+            rows['wfdisc'][0].dir = idir
+
+            # manage the ids
+            make_atomic(last, **rows)
+
+            # add rows to the database
+            # XXX: not done very elegantly.  some problem rows are simply skipped.
+            for table, instances in rows.items():
+                if instances:
+                    # could be empty []
+                    try:
+                        session.add_all(instances)
+                        session.commit()
+                    except exc.IntegrityError as e:
+                        # duplicate or nonexistant primary keys
+                        session.rollback()
+                        print("rollback {}".format(table))
+                    except exc.OperationalError as e:
+                        # no such table, or database is locked
+                        session.rollback()
+                    print("rollback {}".format(table))

--- a/pisces/commands/sac2db.py
+++ b/pisces/commands/sac2db.py
@@ -13,8 +13,8 @@ from obspy.io.sac.core import _is_sac
 
 import pisces as ps
 from pisces.util import get_lastids, url_connect
-from pisces.tables.kbcore import CORETABLES
 import pisces.io.sac as sac
+from .util import get_or_create_tables, dicts2rows, get_files
 
 
 def get_plugins(plugins):
@@ -40,98 +40,18 @@ def get_plugins(plugins):
     return plugin_functions
 
 
-def get_files(file_list):
-    """
-    Return a sequence of SAC file names from either a list of file names
-    (trivial) or a text file list (presumable because there are too many files
-    to use normal shell expansion).
-
-    """
-    if len(file_list) == 1 and not _is_sac(file_list[0]):
-        #make a generator of non-blank lines
-        try:
-            listfile = open(file_list[0], 'r')
-            files = (line.strip() for line in listfile if line.strip())
-        except IOError:
-            msg = "{0} does not exist.".format(file_list[0])
-            raise IOError(msg)
-    else:
-        files = file_list
-
-    return files
-
-
-# TODO: put in util.py ?
-def get_or_create_tables(session, prefix=None, create=True, **tables):
-    """
-    Load or create canonical ORM KB Core table classes.
-
-    Parameters
-    ----------
-    session : sqlalchemy.orm.Session
-    prefix : str
-        Prefix for canonical table names, e.g. 'myaccount.' or 'TA_' (no owner/schema).
-        Canonical table names are used if no prefix is provided.
-    create : bool
-        If True, create tables that don't yet exist.
-
-    Canonical table keyword/tablename string pairs, such as site='other.site',
-    can override prefix.  For example, you may want to use a different Lastid
-    table, so that ids don't start from 1.
-
-    Returns
-    -------
-    tables : dict
-        A mapping between canonical table names and SQLA declarative classes
-        with the correct __tablename__.
-        e.g. {'origin': Origin, ...}
-
-    """
-    # The Plan:
-    # 1. For each core table, build or get the table name
-    # 2. If it's a vanilla table name, just use a pre-packaged table class
-    # 3. If not, try to autoload it.
-    # 4. If it doesn't exist, make it from a prototype and create it in the database.
-
-    # TODO: check options for which tables to produce.
-
-    if not prefix:
-        prefix = ''
-
-    tabledict = {}
-    for coretable in CORETABLES.values():
-        # build the table name
-        fulltablename = tables.get(coretable.name, prefix + coretable.name)
-
-        # put table classes into the tables dictionary
-        if fulltablename == coretable.name:
-            # it's a vanilla table name. just use a pre-packaged table class instead of making one.
-            tabledict[coretable.name] = coretable.table
-        else:
-            tabledict[coretable.name] = ps.make_table(fulltablename, coretable.prototype)
-
-        tabledict[coretable.name].__table__.create(session.bind, checkfirst=True)
-
-    session.commit()
-
-    return tabledict
-
-
-def dicts2rows(dicts, classes):
-    for table, dcts in dicts.items():
-        cls = classes[table]
-        dicts[table] = [cls(**dct) for dct in dcts]
-
-    return dicts
-
-
 def make_atomic(last, **rows):
     """
     Unify related table instances/row, including: ids, dir, and dfile
+
+    Parameters
+    ----------
+    last : obspy.AttributeDict
+        {'keyvalue': lastid instance, ...}
+    rows : dict
+        {'canonical tablename': [list of row instances], ...} of _related_
+        instances from a single SAC header?
     """
-    # last is an AttributeDict of {'keyvalue': lastid instance, ...}
-    # rows is a dictionary of {'canonical tablename': [list of instances], ...}
-    # of _related_ instances from a single SAC header?
     # TODO: check existance of rows before changing their ids.
 
     #print rows
@@ -178,9 +98,6 @@ def apply_plugins(plugins, **rows):
     return rows
 
 
-def sac2db(session, tables, files, plugins=None, absolute_paths=False):
-    pass
-
 # TODO: make this main also accept a get_iterable and get_row_dicts functions,
 #   so it can be renamed to iter2db and re-used in a sac2db.py and miniseed2db.py
 def main(**kwargs):
@@ -207,7 +124,7 @@ def main(**kwargs):
     session = kwargs['session']
 
     if kwargs.get('file_list'):
-        files = get_files(kwargs['file_list'])
+        files = get_files(kwargs['file_list'], file_check=_is_sac)
     else:
         files = kwargs['files']
 
@@ -224,10 +141,9 @@ def main(**kwargs):
 
         tr = read(sacfile, format='SAC', debug_headers=True)[0]
 
+        # sachdr2tables produces table dictionaries
         # rows needs to be a dict of lists, for make_atomic
-        # row_dicts = get_row_dicts(tr.stats.sac) # put in the whole trace, to determine byte order?
         dicts = sac.sachdr2tables(tr.stats.sac, tables=tables.keys())
-        # row_instances = dicts_to_instances(row_dicts, tables)
         rows = dicts2rows(dicts, tables)
 
         # manage dir, dfile, datatype

--- a/pisces/commands/util.py
+++ b/pisces/commands/util.py
@@ -1,0 +1,102 @@
+"""
+Helper functions for comman-line utilities.
+
+"""
+from pisces.tables.kbcore import CORETABLES
+
+
+def get_or_create_tables(session, prefix=None, create=True, **tables):
+    """
+    Load or create canonical ORM KB Core table classes.
+
+    Parameters
+    ----------
+    session : sqlalchemy.orm.Session
+    prefix : str
+        Prefix for canonical table names, e.g. 'myaccount.' or 'TA_' (no owner/schema).
+        Canonical table names are used if no prefix is provided.
+    create : bool
+        If True, create tables that don't yet exist.
+
+    Canonical table keyword/tablename string pairs, such as site='other.site',
+    can override prefix.  For example, you may want to use a different Lastid
+    table, so that ids don't start from 1.
+
+    Returns
+    -------
+    tables : dict
+        A mapping between canonical table names and SQLA declarative classes
+        with the correct __tablename__.
+        e.g. {'origin': Origin, ...}
+
+    """
+    # The Plan:
+    # 1. For each core table, build or get the table name
+    # 2. If it's a vanilla table name, just use a pre-packaged table class
+    # 3. If not, try to autoload it.
+    # 4. If it doesn't exist, make it from a prototype and create it in the database.
+
+    # TODO: check options for which tables to produce.
+
+    if not prefix:
+        prefix = ''
+
+    tabledict = {}
+    for coretable in CORETABLES.values():
+        # build the table name
+        fulltablename = tables.get(coretable.name, prefix + coretable.name)
+
+        # put table classes into the tables dictionary
+        if fulltablename == coretable.name:
+            # it's a vanilla table name. just use a pre-packaged table class instead of making one.
+            tabledict[coretable.name] = coretable.table
+        else:
+            tabledict[coretable.name] = ps.make_table(fulltablename, coretable.prototype)
+
+        tabledict[coretable.name].__table__.create(session.bind, checkfirst=True)
+
+    session.commit()
+
+    return tabledict
+
+
+def dicts2rows(dicts, classes):
+    """
+    Expands lists of table dictionaries into table class instances.
+
+    dicts : dict
+        Keys are canonical table names, values are lists of row dicts for that table.
+    classes : dict
+        Keys are canonical table names, values are table classes.
+
+    """
+    for table, dcts in dicts.items():
+        cls = classes[table]
+        dicts[table] = [cls(**dct) for dct in dcts]
+
+    return dicts
+
+def get_files(file_list, file_check=None):
+    """
+    Return a sequence of file names from either a list of file names
+    (trivial) or a text file list (presumable because there are too many files
+    to use normal shell expansion).
+
+    Optionally, supply a file_check function that accepts a file name, and returns
+    a boolean True if the file is the desired format.  This only checks the first
+    file, and raises an IOError if False, assuming all subsequent files will be
+    the wrong format.
+
+    """
+    if len(file_list) == 1 and not file_check(file_list[0]):
+        #make a generator of non-blank lines
+        try:
+            with open(file_list[0], 'r') as listfile:
+                files = (line.strip() for line in listfile if line.strip())
+        except IOError:
+            msg = "{0} does not exist.".format(file_list[0])
+            raise IOError(msg)
+    else:
+        files = file_list
+
+    return files

--- a/pisces/io/mseed.py
+++ b/pisces/io/mseed.py
@@ -1,0 +1,76 @@
+
+def mseedhdr2tables(stats, wfdisc=None, site=None, sitechan=None, affiliation=None):
+    """
+    Scrapes an ObsPy Stats header instance into various database table rows.
+
+    If table classes are provided, filled class instances are returned,
+    otherwise dicts are returned.
+
+    Parameters
+    ----------
+    stats : obspy.core.Stats instance
+    wfdisc, site, sitechan, affiliation : SQLAlchemy ORM table classes
+
+    Returns
+    -------
+    rows : dict
+        Keys are canonical table names, values are lists of dicts or class instances.
+    
+    Notes
+    -----
+    wfdisc.datatype is set to 'sd', which is not an actual KB Core or CSS 3.0
+    datatype, but is supported within Pisces, and does not require data
+    reformating/copying.
+
+    """
+    # 1. Assign stats values to column values
+    # 2. Assign column values to table row dicts
+    # 3. If provided, convert row dicts to class instances
+    # 4. Return results as a dict of lists.
+
+    # 1.
+    net = stats['network']
+    sta = stats['station']
+    chan = stats['channel']
+    samprate = stats['sampling_rate']
+    nsamp = stats['npts']
+    calib = stats.get('calib', 1.0)
+    _time = stats['starttime'].timestamp
+    _endtime = stats['endtime'].timestamp
+
+    # 2.
+    wfrow = {'sta': sta,
+             'chan': chan,
+             'time': _time,
+             'endtime': _endtime,
+             'calib': calib,
+             'datatype': 'sd'}
+
+    siterow = {'sta': sta}
+    
+    sitechanrow = {'sta': sta,
+                   'chan': chan}
+    
+    affilrow = {'net': net,
+                'sta': sta}
+    
+    # 3.
+    if wfdisc:
+        wfdiscrow = wfdisc(**wfrow)
+    
+    if site:
+        siterow = site(**siterow)
+    
+    if sitechan:
+        sitechanrow = sitechan(**sitechanrow)
+    
+    if affiliation:
+        affilrow = affiliation(**affilrow)
+
+    # 4.
+    rows = {'wfdisc': [wfdiscrow],
+            'site': [siterow],
+            'sitechan': [sitechanrow],
+            'affiliation': [affilrow]}
+    
+    return rows

--- a/pisces/schema/css3.py
+++ b/pisces/schema/css3.py
@@ -455,7 +455,7 @@ szz = Column(Float(24),
              info={'default': -100000000, 'parse': parse_float, 'dtype': 'float', 'width': 15, 'format': '15.4f'})
 
 tagid = Column(Integer,
-               info={'default': -1, 'parse': parse_float, 'dtype': 'float', 'width': 8, 'format': '8d'})
+               info={'default': -1, 'parse': parse_int, 'dtype': 'int', 'width': 8, 'format': '8d'})
 
 tagname = Column(String(8),
                  info={'default': '-', 'parse': parse_str, 'dtype': 'a8', 'width': 8, 'format': '8.8s'})
@@ -931,7 +931,7 @@ class Wftag(Base):
 
     @declared_attr
     def __table_args__(cls):
-        return (PrimaryKeyConstraint('tagid'), UniqueConstraint('tagname', 'tagid', 'wfid'),)
+        return (PrimaryKeyConstraint('tagname', 'tagid', 'wfid'),)
 
     tagname = tagname.copy()
     tagid = tagid.copy()

--- a/pisces/schema/kbcore.py
+++ b/pisces/schema/kbcore.py
@@ -497,7 +497,7 @@ szz = Column(Float(24),
              info={'default': -100000000, 'parse': parse_float, 'dtype': 'float', 'width': 15, 'format': '15.4f'})
 
 tagid = Column(Integer,
-               info={'default': -1, 'parse': parse_float, 'dtype': 'float', 'width': 9, 'format': '9d'})
+               info={'default': -1, 'parse': parse_int, 'dtype': 'int', 'width': 9, 'format': '9d'})
 
 tagname = Column(String(8),
                  info={'default': '-', 'parse': parse_str, 'dtype': 'a8', 'width': 8, 'format': '8.8s'})
@@ -967,7 +967,7 @@ class Wftag(Base):
 
     @declared_attr
     def __table_args__(cls):
-        return (PrimaryKeyConstraint('tagid'), UniqueConstraint('tagname', 'tagid', 'wfid'),)
+        return (PrimaryKeyConstraint('tagname', 'tagid', 'wfid'),)
 
     tagname = tagname.copy()
     tagid = tagid.copy()


### PR DESCRIPTION
In both `kbcore.py` and `css3.py` the following errors were fixed:

* `tagid` was improperly parsed as a float instead of an integer.
* Wftag table primary keys should've been `tagname`, `tagid`, and `wfid`